### PR TITLE
Ensure pluralization of irregular words to be idempotent

### DIFF
--- a/lib/dry/inflector/inflections.rb
+++ b/lib/dry/inflector/inflections.rb
@@ -132,12 +132,13 @@ module Dry
       #   inflector = Dry::Inflector.new do |inflections|
       #     inflections.singular "octopus", "octopi"
       #   end
-      def irregular(singular, plural)
+      def irregular(singular, plural) # rubocop:disable Metrics/AbcSize
         uncountables.delete(singular)
         uncountables.delete(plural)
 
-        add_irregular(singular, plural, plurals)
-        add_irregular(plural, singular, singulars)
+        plural(Regexp.new("(#{singular[0, 1]})#{singular[1..-1]}$", "i"), '\1' + plural[1..-1])
+        plural(Regexp.new("(#{plural[0, 1]})#{plural[1..-1]}$", "i"), '\1' + plural[1..-1])
+        singular(Regexp.new("(#{plural[0, 1]})#{plural[1..-1]}$", "i"), '\1' + singular[1..-1])
       end
 
       # Add a custom rule for uncountable words
@@ -183,20 +184,6 @@ module Dry
       end
 
       private
-
-      # Add irregular inflection
-      #
-      # @param rule [String] the rule
-      # @param replacement [String] the replacement
-      #
-      # @return [undefined]
-      #
-      # @since 0.1.0
-      # @api private
-      def add_irregular(rule, replacement, target)
-        head, *tail = rule.chars.to_a
-        rule(/(#{head})#{tail.join}\z/i, '\1' + replacement[1..-1], target)
-      end
 
       # Add a new rule
       #

--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -89,8 +89,6 @@ module Dry
           inflect.irregular("human", "humans") # NOTE: this is here only to override the previous rule
           inflect.irregular("child", "children")
           inflect.irregular("sex", "sexes")
-          inflect.irregular("move", "moves")
-          inflect.irregular("cow", "cows")
           inflect.irregular("foot", "feet")
           inflect.irregular("tooth", "teeth")
           inflect.irregular("goose", "geese")

--- a/spec/support/fixtures/pluralize.rb
+++ b/spec/support/fixtures/pluralize.rb
@@ -10,6 +10,20 @@ module Fixtures
       PENDING
     end
 
+    def self.irregular
+      IRREGULAR
+    end
+
+    IRREGULAR = {
+      "person" => "people",
+      "man"    => "men",
+      "child"  => "children",
+      "sex"    => "sexes",
+      "foot"   => "feet",
+      "tooth"  => "teeth",
+      "goose"  => "geese"
+    }.freeze
+
     CASES = {
       #
       # Test cases from Inflecto
@@ -30,8 +44,6 @@ module Fixtures
       "axis"         => "axes",
       "crisis"       => "crises",
       "testis"       => "testes",
-      "child"        => "children",
-      "person"       => "people",
       "tomato"       => "tomatoes",
       "buffalo"      => "buffaloes",
       "quiz"         => "quizzes",
@@ -53,7 +65,6 @@ module Fixtures
       "hive"         => "hives",
       "athlete"      => "athletes",
       "dwarf"        => "dwarves",
-      "man"          => "men",
       "woman"        => "women",
       "sportsman"    => "sportsmen",
       "branch"       => "branches",
@@ -330,10 +341,6 @@ module Fixtures
       "tableau" => "tableaux",
       # irregular
       "cactus" => "cacti",
-      "foot"   => "feet",
-      "tooth"  => "teeth",
-      "goose"  => "geese",
-      "sex"    => "sexes",
       # uncountable
       "deer"      => "deer",
       "means"     => "means",
@@ -387,7 +394,7 @@ module Fixtures
       "classes" => "classes",
       "glasses" => "glasses",
       "kisses" => "kisses"
-    }.freeze
+    }.merge(IRREGULAR).freeze
 
     # Missing rule or exception?
     PENDING = {

--- a/spec/unit/dry/inflector/pluralize_spec.rb
+++ b/spec/unit/dry/inflector/pluralize_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Dry::Inflector do
       end
     end
 
+    Fixtures::Pluralize.irregular.each do |singular, plural|
+      it "#{singular} => #{plural} is idempotent" do
+        expect(subject.pluralize(subject.pluralize(singular))).to eq(plural)
+      end
+    end
+
     Fixtures::Pluralize.pending.each do |singular, plural|
       pending "missing exception or rule for #{singular} => #{plural}"
     end


### PR DESCRIPTION
Tentatively closes #7 

It makes pluralization of irregular words idempotent:

```ruby
require "dry/inflector"

Dry::Inflector.new.pluralize("people") # => "people"
```

---

It's a backward compatibility fix for `inflecto` `v0.0.2`.

⚠️ **Please read this** ⚠️ 

While porting `inflecto` to `dry-inflector`, I looked at `master` branch of `inflecto`. I noticed a difference between `v0.0.2` and `master` in terms of how irregular rules are added. This is the commit: https://github.com/mbj/inflecto/commit/05468ea24208e5cbae9290545a9b620b215b487d#diff-3f76f8e104060c974809c409ab7727d3

I assume that the code before this commit (probably taken from `ActiveSupport::Inflector`) was **accidentally** making the pluralization of irregular words idempotent. (`"people" => "people"`).

Indeed, if you use `master` version of `inflecto` (at `a39d9a5`):

```
irb(main):001:0> Inflecto.pluralize("people")
=> "peoples"
```

/cc @mbj 