### PR TITLE
Add #constantize and #foreign_key

### DIFF
--- a/lib/dry/inflector.rb
+++ b/lib/dry/inflector.rb
@@ -52,6 +52,26 @@ module Dry
       input.to_s.gsub(/\/(.?)/) { "::#{Regexp.last_match(1).upcase}" }.gsub(/(?:\A|_)(.)/) { Regexp.last_match(1).upcase }
     end
 
+    # Find a constant with the name specified in the argument string
+    #
+    # The name is assumed to be the one of a top-level constant,
+    # constant scope of caller is ignored
+    #
+    # @param input [String,Symbol] the input
+    # @return [Class, Module] the class or module
+    #
+    # @since 0.1.0
+    #
+    # @example
+    #   require "dry/inflector"
+    #
+    #   inflector = Dry::Inflector.new
+    #   inflector.constantize("Module")         # => Module
+    #   inflector.constantize("Dry::Inflector") # => Dry::Inflector
+    def constantize(input)
+      Object.const_get(input)
+    end
+
     # Classify a string
     #
     # @param input [String,Symbol] the input
@@ -120,6 +140,20 @@ module Dry
       result.tr!("_", " ")
       result.capitalize!
       result
+    end
+
+    # Creates a foreign key name
+    #
+    # @param input [String, Symbol] the input
+    # @return [String] foreign key
+    #
+    # @example
+    #   require "dry/inflector"
+    #
+    #   inflector = Dry::Inflector.new
+    #   inflector.foreign_key("Message") => "message_id"
+    def foreign_key(input)
+      "#{underscorize(demodulize(input))}_id"
     end
 
     # Ordinalize a number

--- a/spec/unit/dry/inflector/constantize_spec.rb
+++ b/spec/unit/dry/inflector/constantize_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Dry::Inflector do
       expect(subject.constantize(i("::Module"))).to eq Module
     end
 
+    it "accepts symbols" do
+      expect(subject.constantize(i(:Module))).to eq Module
+    end
+
     it "constantizes nested constant Dry::Inflector::Inflections" do
       expect(subject.constantize(i("Dry::Inflector::Inflections"))).to eq Dry::Inflector::Inflections
     end

--- a/spec/unit/dry/inflector/constantize_spec.rb
+++ b/spec/unit/dry/inflector/constantize_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Inflector do
+  describe "#constantize" do
+    it "constantizes Module" do
+      expect(subject.constantize(i("Module"))).to eq Module
+    end
+
+    it "constantizes ::Module" do
+      expect(subject.constantize(i("::Module"))).to eq Module
+    end
+
+    it "constantizes nested constant Dry::Inflector::Inflections" do
+      expect(subject.constantize(i("Dry::Inflector::Inflections"))).to eq Dry::Inflector::Inflections
+    end
+
+    it "does not search ancestors" do
+      module Foo
+        class Bar
+          VAL = 10
+        end
+
+        class Baz < Bar; end
+      end
+
+      expect do
+        subject.constantize(i("Foo::Baz::VAL"))
+      end.to_not raise_error(NameError)
+    end
+
+    it "searches in const_missing" do
+      module Foo
+        class Bar
+          def self.const_missing(name)
+            name.to_s == "Const" ? Baz : super
+          end
+        end
+
+        class Baz < Bar; end
+
+        def self.const_missing(name)
+          name.to_s == "Autoloaded" ? Bar : super
+        end
+      end
+
+      expect(subject.constantize(i("Foo::Autoloaded::Const"))).to eq Foo::Baz
+      expect(subject.constantize(i("Foo::Bar::Const"))).to eq Foo::Baz
+    end
+
+    it "raises exception when empty string given" do
+      expect do
+        subject.constantize(i(""))
+      end.to raise_error(NameError)
+    end
+
+    it "raises exception when constant not found" do
+      expect do
+        subject.constantize(i("Qwerty"))
+      end.to raise_error(NameError)
+    end
+  end
+end

--- a/spec/unit/dry/inflector/foreign_key_spec.rb
+++ b/spec/unit/dry/inflector/foreign_key_spec.rb
@@ -9,5 +9,9 @@ RSpec.describe Dry::Inflector do
     it "demodulizes string first: Admin::Post => post_id" do
       expect(subject.foreign_key(i("Admin::Post"))).to eq "post_id"
     end
+
+    it "accepts symbols" do
+      expect(subject.foreign_key(i(:message))).to eq "message_id"
+    end
   end
 end

--- a/spec/unit/dry/inflector/foreign_key_spec.rb
+++ b/spec/unit/dry/inflector/foreign_key_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Inflector do
+  describe "#foreign_key" do
+    it "adds _id to downcased string: Message => message_id" do
+      expect(subject.foreign_key(i("Message"))).to eq "message_id"
+    end
+
+    it "demodulizes string first: Admin::Post => post_id" do
+      expect(subject.foreign_key(i("Admin::Post"))).to eq "post_id"
+    end
+  end
+end


### PR DESCRIPTION
I have simplified constantize to just a `Object.const_get`.

Related: https://github.com/dry-rb/dry-inflector/issues/5#issuecomment-344602652

Note: #constantize is here just for back compatibility with other libraries.
It's much better to use the plain #const_get because it will use the current context.

```ruby
module Dry
  class Inflector
    VERSION = "0.1.0"

    const_get("VERSION") #=> "0.1.0"
    Object.const_get("VERSION") #=> NameError: uninitialized constant VERSION
    inflector.constantize("VERSION") #=> Don't work either, because uses Object.const_get
  end
end
```