### PR TITLE
Allow gem to be required as 'dry-inflector'

### DIFF
--- a/lib/dry-inflector.rb
+++ b/lib/dry-inflector.rb
@@ -1,0 +1,1 @@
+require 'dry/inflector'


### PR DESCRIPTION
Without this, it had to be required as 'dry/inflector', which can look
out of place between the other dry-libs.