### PR TITLE
CI: Use latest Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 bundler_args: --without tools benchmarks
 script:
@@ -10,7 +9,8 @@ before_install:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - jruby-9.1.16.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.2.6.0


### PR DESCRIPTION
This PR updates the CI matri.

  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration