### PR TITLE
Demonstrate partially-lower-case acronyms in docs

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -64,9 +64,9 @@ inflector.pluralize("dry-inflector") # => "dry-inflector"
 require "dry/inflector"
 
 inflector = Dry::Inflector.new do |inflections|
-  inflections.acronym "HTTP", "XML"
+  inflections.acronym "API", "OpenGL"
 end
 
-inflector.underscore("XMLHTTPRequest") # => "xml_http_request"
-inflector.camelize("xml_http_request") # => "XMLHTTPRequest"
+inflector.camelize("opengl_api") # => "OpenGLAPI"
+inflector.underscore("OpenGLAPI") # => "opengl_api"
 ```


### PR DESCRIPTION
It's not immediately obvious that acronyms containing lower-case characters, like "OpenGL", are handled correctly.

This updates the example in the documentation to use a normal acronym, and a partially lower-case one.