### PR TITLE
Fix `Dry::Inflector#constantize` to not inherit constants from sibling namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.2.1 (unreleased)
+
+
+### Fixed
+
+- [Luca Guidi] Fixed `Dry::Inflector#constantize` to not inherit constants from siblings namespaces
+- ```ruby
+- module Foo
+-   module Bar
+-     VERSION = "0.1.0"
+-   end
+-
+-   module Baz
+-   end
+- end
+-
+- module Test
+- end
+-
+- module Check
+- end
+-
+- inflector = Dry::Inflector.new
+-
+- # BEFORE
+- inflector.constantize("Foo::Baz::VERSION") # => VERSION
+- inflector.constantize("Test::Check") # => Check
+-
+- # AFTER
+- inflector.constantize("Foo::Baz::VERSION") # => raises NameError
+- inflector.constantize("Test::Check") # => raises NameError
+- ```
+
 ## 0.2.0 2019-10-13
 
 

--- a/lib/dry/inflector.rb
+++ b/lib/dry/inflector.rb
@@ -86,7 +86,7 @@ module Dry
     #   inflector.constantize("Module")         # => Module
     #   inflector.constantize("Dry::Inflector") # => Dry::Inflector
     def constantize(input)
-      Object.const_get(input)
+      Object.const_get(input, false)
     end
 
     # Classify a string

--- a/spec/unit/dry/inflector/constantize_spec.rb
+++ b/spec/unit/dry/inflector/constantize_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Dry::Inflector do
         class Baz < Bar; end
       end
 
-      expect(subject.constantize(i('Foo::Baz::VAL'))).to be(10)
+      expect(subject.constantize(i('Foo::Bar::VAL'))).to be(10)
+      expect { subject.constantize(i('Foo::Baz::VAL')) }.to raise_error(NameError)
     end
 
     it 'searches in const_missing' do


### PR DESCRIPTION
```ruby
module Foo
  module Bar
    VERSION = "0.1.0"
  end

  module Baz
  end
end

module Test
end

module Check
end

inflector = Dry::Inflector.new

# BEFORE
inflector.constantize("Foo::Baz::VERSION") # => VERSION
inflector.constantize("Test::Check") # => Check

# AFTER
inflector.constantize("Foo::Baz::VERSION") # => raises NameError
inflector.constantize("Test::Check") # => raises NameError
```