### PR TITLE
Add more default acronyms

### DIFF
--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -110,7 +110,7 @@ module Dry
         # @since 0.1.2
         # @api private
         def self.acronyms(inflect)
-          inflect.acronym(*%w[JSON HTTP OpenSSL HMAC])
+          inflect.acronym(*%w[JSON HTTP OpenSSL HMAC CSRF API])
         end
 
         private_class_method :plural, :singular, :irregular, :uncountable, :acronyms

--- a/spec/unit/dry/inflector/acronym_spec.rb
+++ b/spec/unit/dry/inflector/acronym_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Dry::Inflector do
   subject do
     Dry::Inflector.new do |inflect|
-      inflect.acronym("API", "RESTful", "RoR", "PhD", "W3C", "SSL", "HTML")
+      inflect.acronym("RESTful", "RoR", "PhD", "W3C", "SSL", "HTML")
     end
   end
 
@@ -29,6 +29,7 @@ RSpec.describe Dry::Inflector do
           ["HTTP::RESTful",     "http/restful",       "HTTP/RESTful"],
           ["HTTP::RESTfulAPI",  "http/restful_api",   "HTTP/RESTful API"],
           ["APIRESTful",        "api_restful",        "API RESTful"],
+          ["CSRF",              "csrf",               "Cross Site Request Forgery"],
 
           # misdirection
           %w[Capistrano capistrano Capistrano],
@@ -42,6 +43,7 @@ RSpec.describe Dry::Inflector do
           expect(subject.camelize(camel)).to eql(camel)
           expect(subject.underscore(camel)).to eql(under)
           expect(subject.underscore(under)).to eql(under)
+
           expect(subject.humanize(human)).to eql(human)
         end
       end


### PR DESCRIPTION
## Enhancement

With dry-rb, Hanami, ROM using a custom inflector for Zeitwerk, we may want to expand the set of default acronyms. Those acronyms are needed to Zeitwerk to correctly require classes like `CSRFToken`. Zeitwerk defaults to CamelCase class names, and must be instructed about the exceptions.

## Added default acronyms:

  * API: Application Programming Interface
  * CSRF: Cross Site Request Forgery