### PR TITLE
Ensure pending cases are still pending

### DIFF
--- a/spec/support/fixtures/pluralize.rb
+++ b/spec/support/fixtures/pluralize.rb
@@ -401,8 +401,7 @@ module Fixtures
       "criterion" => "criteria",
       "thesaurus" => "thesauri",
       "plus" => "plusses",
-      "virus" => "viruses",
-      "Swiss" => "Swiss"
+      "virus" => "viruses"
     }.freeze
   end
 end

--- a/spec/unit/dry/inflector/pluralize_spec.rb
+++ b/spec/unit/dry/inflector/pluralize_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Dry::Inflector do
 
     Fixtures::Pluralize.pending.each do |singular, plural|
       pending "missing exception or rule for #{singular} => #{plural}"
+
+      it "fails as expected since it's 'pending' (tip: remove it from pending!)" do
+        expect(subject.singularize(singular)).to_not eq(plural)
+      end
     end
 
     it "accepts symbols" do

--- a/spec/unit/dry/inflector/singularize_spec.rb
+++ b/spec/unit/dry/inflector/singularize_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Dry::Inflector do
 
     Fixtures::Singularize.pending.each do |plural, singular|
       pending "missing exception or rule for #{plural} => #{singular}"
+
+      it "fails as expected since it's 'pending' (tip: remove it from pending!)" do
+        expect(subject.singularize(plural)).to_not eq(singular)
+      end
     end
 
     it "accepts symbols" do


### PR DESCRIPTION
This should make implementing pending cases a bit simpler, with better feedback. Once the inflection rules implement the pending case, the test will fail and we can get a green suite by removing it from "pending".

This also removes a pending example for 'Swiss' since it's not pending anymore :) (Which is exactly the kind of thing I was hoping to find in the future)