### PR TITLE
Fix singularizing -us suffix

### DIFF
--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -69,7 +69,7 @@ module Dry
           inflect.singular(/(ss)\z/i, '\1')
           inflect.singular(/(x|ch|ss|sh)es\z/i, '\1')
           inflect.singular(/([m|l])ice\z/i, '\1ouse')
-          inflect.singular(/(bus)(es)?\z/i, '\1')
+          inflect.singular(/(us)(es)?\z/i, '\1')
           inflect.singular(/(o)es\z/i, '\1')
           inflect.singular(/(shoe)s\z/i, '\1')
           inflect.singular(/(cris|ax|test)(is|es)\z/i, '\1is')

--- a/spec/support/fixtures/singularize.rb
+++ b/spec/support/fixtures/singularize.rb
@@ -62,7 +62,12 @@ module Fixtures
       "testis" => "testis",
       "thesis" => "thesis",
       "analysis" => "analysis",
-      "octopus" => "octopus",
+      "octopuses" => "octopus",
+      "pluses" => "plus",
+      "cactuses" => "cactus",
+      "bonuses" => "bonus",
+      "geniuses" => "genius",
+      "walruses" => "walrus",
 
       # ==== rules
 
@@ -166,11 +171,9 @@ module Fixtures
     # Missing exceptions or missing rules?
     PENDING = {
       "cacti" => "cactus",
-      "cactuses" => "cactus",
       "thesauri" => "thesaurus",
       "phenomena" => "phenomenon",
       "drives" => "drive",
-      "pluses" => "plus",
       "thieves" => "thief",
       "criteria" => "criterion",
       "postgres" => "postgres"


### PR DESCRIPTION
Closes #33

(Locally, I used #37 to find that `pluses` and `cactuses` should now be removed from "pending" too :D I moved them to regular expectations.)

I also saw that `octopus` was marked as a plural, which it's not, so I put the actual plural in there.