### PR TITLE
Omit dashes from camelcase

### DIFF
--- a/lib/dry/inflector.rb
+++ b/lib/dry/inflector.rb
@@ -327,7 +327,7 @@ module Dry
     def internal_camelize(input, upper)
       input = input.to_s.dup
       input.sub!(/^[a-z\d]*/) { |match| inflections.acronyms.apply_to(match, capitalize: upper) }
-      input.gsub!(%r{(?:_|(/))([a-z\d]*)}i) do
+      input.gsub!(%r{(?:[_-]|(/))([a-z\d]*)}i) do
         m1 = Regexp.last_match(1)
         m2 = Regexp.last_match(2)
         "#{m1}#{inflections.acronyms.apply_to(m2)}"

--- a/spec/support/fixtures/camelize_lower.rb
+++ b/spec/support/fixtures/camelize_lower.rb
@@ -14,6 +14,7 @@ module Fixtures
       "merb" => "merb",
       "data_mapper" => "dataMapper",
       "data-mapper" => "dataMapper",
+      "data---mapper" => "dataMapper",
       "dry/inflector" => "dry::Inflector",
       "dry/inflector/inflections" => "dry::Inflector::Inflections",
       "blog_post/author" => "blogPost::Author",

--- a/spec/support/fixtures/camelize_lower.rb
+++ b/spec/support/fixtures/camelize_lower.rb
@@ -13,6 +13,7 @@ module Fixtures
     CASES = {
       "merb" => "merb",
       "data_mapper" => "dataMapper",
+      "data-mapper" => "dataMapper",
       "dry/inflector" => "dry::Inflector",
       "dry/inflector/inflections" => "dry::Inflector::Inflections",
       "blog_post/author" => "blogPost::Author",

--- a/spec/support/fixtures/camelize_upper.rb
+++ b/spec/support/fixtures/camelize_upper.rb
@@ -14,6 +14,7 @@ module Fixtures
       "merb" => "Merb",
       "data_mapper" => "DataMapper",
       "data-mapper" => "DataMapper",
+      "data---mapper" => "DataMapper",
       "dry/inflector" => "Dry::Inflector",
       "dry/inflector/inflections" => "Dry::Inflector::Inflections",
       "blog_post/author" => "BlogPost::Author",

--- a/spec/support/fixtures/camelize_upper.rb
+++ b/spec/support/fixtures/camelize_upper.rb
@@ -13,6 +13,7 @@ module Fixtures
     CASES = {
       "merb" => "Merb",
       "data_mapper" => "DataMapper",
+      "data-mapper" => "DataMapper",
       "dry/inflector" => "Dry::Inflector",
       "dry/inflector/inflections" => "Dry::Inflector::Inflections",
       "blog_post/author" => "BlogPost::Author",


### PR DESCRIPTION
The `internal_camelize` method should omit dashes from strings being converted to CamelCase, as CamelCase does not typically allow dashes. Thus, treat dashes in the same way as underscores and omit them.