### PR TITLE
Attempt to address unexpected inflections

### DIFF
--- a/lib/dry/inflector.rb
+++ b/lib/dry/inflector.rb
@@ -298,7 +298,9 @@ module Dry
     # @since 0.1.0
     # @api private
     def uncountable?(input)
-      input.match?(/\A[[:space:]]*\z/) || inflections.uncountables.include?(input.downcase)
+      input.match?(/\A[[:space:]]*\z/) ||
+        inflections.uncountables.include?(input.downcase) ||
+        inflections.uncountables.include?(input.split(/_|\b/).last.downcase)
     end
 
     # @return [String]

--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -75,7 +75,7 @@ module Dry
           inflect.singular(/(cris|ax|test)(is|es)\z/i, '\1is')
           inflect.singular(/(octop|vir)(us|i)\z/i, '\1us')
           inflect.singular(/(alias|status)(es)?\z/i, '\1')
-          inflect.singular(/^(ox)en/i, '\1')
+          inflect.singular(/(ox)en/i, '\1')
           inflect.singular(/(vert|ind)ices\z/i, '\1ex')
           inflect.singular(/(matr)ices\z/i, '\1ix')
           inflect.singular(/(quiz)zes\z/i, '\1')

--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -56,7 +56,7 @@ module Dry
           inflect.singular(/s\z/i, "")
           inflect.singular(/(n)ews\z/i, '\1ews')
           inflect.singular(/([ti])a\z/i, '\1um')
-          inflect.singular(/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)\z/i,
+          inflect.singular(/(analy|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)\z/i,
                            '\1\2sis')
           inflect.singular(/(^analy)(sis|ses)\z/i, '\1sis')
           inflect.singular(/([^f])ves\z/i, '\1fe')

--- a/spec/unit/dry/inflector/singularize_spec.rb
+++ b/spec/unit/dry/inflector/singularize_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Dry::Inflector do
       it "singularizes #{plural} => #{singular}" do
         expect(subject.singularize(i(plural))).to eq(singular)
       end
+
+      it "singularizes _#{plural} => _#{singular}" do
+        expect(subject.singularize(i("_#{plural}"))).to eq("_#{singular}")
+      end
     end
 
     Fixtures::Singularize.pending.each do |plural, singular|

--- a/spec/unit/dry/inflector/singularize_spec.rb
+++ b/spec/unit/dry/inflector/singularize_spec.rb
@@ -7,8 +7,16 @@ RSpec.describe Dry::Inflector do
         expect(subject.singularize(i(plural))).to eq(singular)
       end
 
-      it "singularizes _#{plural} => _#{singular}" do
-        expect(subject.singularize(i("_#{plural}"))).to eq("_#{singular}")
+      it "singularizes test_#{plural} => test_#{singular}" do
+        expect(subject.singularize(i("test_#{plural}"))).to eq("test_#{singular}")
+      end
+
+      it "singularizes test-#{plural} => test-#{singular}" do
+        expect(subject.singularize(i("test-#{plural}"))).to eq("test-#{singular}")
+      end
+
+      it "singularizes 'test #{plural}' => 'test #{singular}'" do
+        expect(subject.singularize(i("test #{plural}"))).to eq("test #{singular}")
       end
     end
 


### PR DESCRIPTION
Addresses #46 

When working with inflections containing multiple words, whether they
are separated by, for example, a space or underscore or hyphen we aren't
seeing the expected results.

I've addressed the singularization problem by not checking for the match
only at the start of the string.

I've addresses the `uncountable?` problem by splitting the inflection
into 'words' and then inflecting the final 'word'.