### PR TITLE
Add "DB" as a default acronym

### DIFF
--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -114,6 +114,7 @@ module Dry
             API
             CSRF
             CSV
+            DB
             HMAC
             HTTP
             JSON

--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -110,7 +110,15 @@ module Dry
         # @since 0.1.2
         # @api private
         def self.acronyms(inflect)
-          inflect.acronym(*%w[JSON HTTP OpenSSL HMAC CSRF API CSV])
+          inflect.acronym(*%w[
+            API
+            CSRF
+            CSV
+            HMAC
+            HTTP
+            JSON
+            OpenSSL
+          ])
         end
 
         private_class_method :plural, :singular, :irregular, :uncountable, :acronyms


### PR DESCRIPTION
Hanami 2.2 will be building around a `DB` namespace in generated apps, so I think it makes sense to push this acronym as low as we can go.