### PR TITLE
Extend the handling of "um" and "ium" pluralisation

### DIFF
--- a/lib/dry/inflector/inflections/defaults.rb
+++ b/lib/dry/inflector/inflections/defaults.rb
@@ -31,6 +31,7 @@ module Dry
           inflect.plural(/(alias|status)\z/i, '\1es')
           inflect.plural(/(buffal|domin|ech|embarg|her|mosquit|potat|tomat)o\z/i, '\1oes')
           inflect.plural(/(?<!b|for)um\z/i, "a")
+          inflect.plural(/(premi|.*[aio]ni|.*ori|.*ari|.*[no]di|.*[pt]i|.*si)um\z/i, '\1ums')
           inflect.plural(/([ti])a\z/i, '\1a')
           inflect.plural(/sis\z/i, "ses")
           inflect.plural(/(.*)(?:([^f]))fe?\z/i, '\1\2ves')

--- a/spec/support/fixtures/pluralize.rb
+++ b/spec/support/fixtures/pluralize.rb
@@ -60,11 +60,9 @@ module Fixtures
       # ==== bugs, typos and reported issues
       "property_fee" => "property_fees",
       "use" => "uses",
-      "premium" => "premiums",
 
       # ==== rules and most common cases
 
-      "forum" => "forums",
       "hive" => "hives",
       "athlete" => "athletes",
       "dwarf" => "dwarves",
@@ -75,7 +73,6 @@ module Fixtures
       "trash" => "trashes",
       "mash" => "mashes",
       "cross" => "crosses",
-      "erratum" => "errata",
       # FIXME: add -ia => -ium cases
       # FIXME: add -ra => -rum cases
       "ray" => "rays",
@@ -161,8 +158,6 @@ module Fixtures
       "basis" => "bases",
       "diagnosis" => "diagnoses",
       "diagnosis_a" => "diagnosis_as",
-      "datum" => "data",
-      "medium" => "media",
       "node_child" => "node_children",
       "experience" => "experiences",
       "day" => "days",
@@ -201,6 +196,18 @@ module Fixtures
       "criterium" => "criteria",
       "perihelium" => "perihelia",
       "aphelium" => "aphelia",
+      "erratum" => "errata",
+      "datum" => "data",
+      "medium" => "media",
+      # um => ums
+      # https://github.com/hanami/utils/issues/106
+      "album" => "albums",
+      "forum" => "forums",
+      "premium" => "premiums",
+      "geranium" => "geraniums",
+      "aquarium" => "aquariums",
+      "podium" => "podiums",
+      "gymnasium" => "gymnasiums",
       # on => a
       "phenomenon" => "phenomena",
       "prolegomenon" => "prolegomena",
@@ -383,8 +390,6 @@ module Fixtures
       "architecture" => "architectures",
       "car" => "cars",
       "area" => "areas",
-      # https://github.com/hanami/utils/issues/106
-      "album" => "albums",
       # https://github.com/hanami/utils/issues/173
       "kitten" => "kittens",
 

--- a/spec/support/fixtures/pluralize.rb
+++ b/spec/support/fixtures/pluralize.rb
@@ -60,6 +60,7 @@ module Fixtures
       # ==== bugs, typos and reported issues
       "property_fee" => "property_fees",
       "use" => "uses",
+      "premium" => "premiums",
 
       # ==== rules and most common cases
 


### PR DESCRIPTION
This adds a rule to try to differentiate between plural "um" and "ium". This is complicated by latin pluralisation hence the ridiculously specific regex. 
This might have been broken by one of my earlier PRs :(
